### PR TITLE
Allow for using custom Eloquent query builder

### DIFF
--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -57,9 +57,9 @@ class Eloquent
         // global removed scopes.
 
         return $model->registerGlobalScopes(
-                (new EloquentQueryBuilder(
+                $model->newEloquentBuilder(
                     Query::unserialize($payload['builder'])
-                ))->setModel($model)
+                )->setModel($model)
             )
             ->setEagerLoads(
                 collect($payload['model']['eager'])->map(function ($callback) {


### PR DESCRIPTION
An optional custom Eloquent query builder class, associated with the model, will now be used when unserializing the query. This is the case when the dev has overwritten the `Model::newEloquentBuilder()` method.