### PR TITLE
Allows serializing `union()` from Query Builder instance

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -38,7 +38,13 @@ class Query
             'orders' => $builder->orders,
             'limit' => $builder->limit,
             'offset' => $builder->offset,
-            'unions' => $builder->unions,
+            'unions' => collect($builder->unions)->map(static function ($union) {
+                if (isset($union['query'])) {
+                    $union['query'] = static::serialize($union['query']);
+                }
+    
+                return $union;
+            })->all(),
             'unionLimit' => $builder->unionLimit,
             'unionOrders' => $builder->unionOrders,
             'lock' => $builder->lock,
@@ -69,6 +75,14 @@ class Query
                 foreach ($value as $index => $where) {
                     if (isset($where['query']) && \is_array($where['query'])) {
                         $value[$index]['query'] = static::unserialize($where['query']);
+                    }
+                }
+            }
+
+            if ($type === 'unions') {
+                foreach ($value as $index => $union) {
+                    if (isset($union['query']) && \is_array($union['query'])) {
+                        $value[$index]['query'] = static::unserialize($union['query']);
                     }
                 }
             }

--- a/tests/Feature/QueryTest.php
+++ b/tests/Feature/QueryTest.php
@@ -48,4 +48,20 @@ class QueryTest extends TestCase
 
         $this->assertSame($builder->toSql(), $unserialize->toSql());
     }
+
+    /** @test */
+    public function it_can_serialize_a_basic_query_builder_with_unions()
+    {
+        $builder = DB::table('users')->where('email', '=', 'crynobone@gmail.com');
+        $union = DB::table('users')->where('email', '=', 'johndoe@gmail.com')
+            ->union($builder);
+
+        $serialized = serialize($union);
+
+        $unserialize = unserialize($serialized);
+
+        $this->assertSame('select * from (select * from "users" where "email" = ?) union select * from (select * from "users" where "email" = ?)', $unserialize->toSql());
+
+        $this->assertSame($union->toSql(), $unserialize->toSql());
+    }
 }


### PR DESCRIPTION
This PR will add support on serializing **union** types to avoid the **Serialization of 'PDO' is not allowed** exception